### PR TITLE
Add a validation for the movie's imdbId

### DIFF
--- a/lib/projection.js
+++ b/lib/projection.js
@@ -69,7 +69,7 @@ Projection.prototype.findTheaters = function(near, options, callback) {
         }
 
         var imdbId = null;
-        if (m.find('.info a').attr('href')) {
+        if (m.find('.info a[href*=imdb]') && m.find('.info a[href*=imdb]').attr('href')) {
           var match = m.find('.info a[href*=imdb]').attr('href').match(/title\/(.*)\//);
           if (match)
             imdbId = match[1];

--- a/test/projection-test.js
+++ b/test/projection-test.js
@@ -59,6 +59,13 @@ describe('Projection', function() {
       });
     })
 
+    it('should return an error if no theaters are found', function(done) {
+      p.findTheaters('Innexistant Place', {}, function(err, theaters) {
+        assert.notEqual(err, null);
+        done();
+      });
+    })
+
     it('should return theaters more quickly the second time', function(done) {
       var start = new Date().getTime();
       p.findTheaters('Montreal', {}, function(err, theaters) {
@@ -76,7 +83,7 @@ describe('Projection', function() {
 
   describe('.findMovie()', function() {
     it('should find a movie\'s showtimes by town', function(done){
-      p.findMovie('Sherbrooke', 'Ted 2', {}, function(err, movie){
+      p.findMovie('Sherbrooke', 'Captain America: Civil War', {}, function(err, movie){
         assert.equal(err, null);
         assert(movie);
         assert(movie.theaters.length > 0);
@@ -87,7 +94,7 @@ describe('Projection', function() {
     })
 
     it('should find a movie\'s showtimes by lat/long', function(done){
-      p.findMovie('45.3838273,-71.8958539', 'Ted 2', {}, function(err, movie){
+      p.findMovie('45.3838273,-71.8958539', 'Captain America: Civil War', {}, function(err, movie){
         assert.equal(err, null);
         assert(movie);
         assert(movie.theaters.length > 0);
@@ -120,12 +127,19 @@ describe('Projection', function() {
       });
     })
 
+    it('should return an error if the movie is not found', function(done) {
+      p.findMovie('Montreal', 'Random movie name that does not exist', {}, function(err, theaters) {
+        assert.notEqual(err, null);
+        done();
+      });
+    })
+
     it('should return a movie more quickly the second time', function(done) {
       var start = new Date().getTime();
-      p.findMovie('Montreal', 'Mad Max', {}, function(err, theaters) {
+      p.findMovie('Montreal', 'Captain America: Civil War', {}, function(err, theaters) {
         var t1 = new Date().getTime() - start;
         start = new Date().getTime();
-        p.findMovie('Montreal', 'Mad Max', {}, function(err, theaters) {
+        p.findMovie('Montreal', 'Captain America: Civil War', {}, function(err, theaters) {
           var t2 = new Date().getTime() - start;
           assert(t1 >= t2); // ~500ms to ~10ms
           assert(t2 < 100); // Expect cache to take lesser than 100ms


### PR DESCRIPTION
There was a missing validation to get a movie's imdbId. It was only checking if there was an anchor with a href attribute, but not if the href attribute contained 'imdb'. So if there was no imdb anchor, the regex was still called, but on an undefined value.

Update the tests movies to work, since the movies in the tests are no longer in theaters (may need to find a permanent solution).

Added 2 tests to test the 2 validations : theathers not found & movie not found.